### PR TITLE
Include Path Tweak

### DIFF
--- a/bphash/CMakeLists.txt
+++ b/bphash/CMakeLists.txt
@@ -8,7 +8,10 @@ add_library(bphash Hasher.cpp
            )
 
 # Include the main source directory (my parent) as an include directory
-target_include_directories(bphash PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(bphash 
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+                                  $<INSTALL_INTERFACE:include>
+                          )
 
 # Where to install the library
 install(TARGETS bphash


### PR DESCRIPTION
At least on my box the resulting `bphash::bphash` target does not know about the include directory for BPHash.  This PR modifies the CMakeLists.txt so that the include directory for the installed target is part of the target's properties.